### PR TITLE
Fix exception when displaying range of "Early - <any time before this month>"

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -24,7 +24,7 @@ export function calcFocusDate(currentFocusedDate, props) {
       end: date,
     };
   }
-  targetInterval.start = startOfMonth(targetInterval.start || new Date());
+  targetInterval.start = startOfMonth(targetInterval.start || targetInterval.end || new Date());
   targetInterval.end = endOfMonth(targetInterval.end || targetInterval.start);
   const targetDate = targetInterval.start || targetInterval.end || shownDate || new Date();
 


### PR DESCRIPTION
I'm not sure which branch a fix should go into.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
Steps:

1. Pass `ranges` of `startDate: undefined` and `endDate: new Date()` to the `<DateRangePicker`component. 
Result: Component shows as expected, with left text showing "Early" and right text showing "April 9 2019". 

1. Pass `ranges` of `startDate: undefined` and `endDate: d.setDate(new Date() - 40);` (need any date that is before the previous month) to the `<DateRangePicker`component. 
Result: Component throws exception, cannot render.

Root cause:
When `undefined` is passed to the `calcFocusDate` function (like in the above case), `targetInterval.start` will be null, and given the current code, it will fallthrough to be assigned to `new Date()` (this occurs on the line I modified). At this point in execution, `targetInterval.start` has just become the date of present day and `targetInterval.end` was correctly set in the past. `targetIntervals` is then passed into `areIntervalsOverlapping`, which does `throw new RangeError('Invalid interval');` because the dates in `targetIntervals` were indeed overlapping.

> Related Issue: #xxx